### PR TITLE
Potential fix for code scanning alert no. 1: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/src/AES.java
+++ b/src/AES.java
@@ -1,4 +1,6 @@
 import java.io.UnsupportedEncodingException;
+import java.security.SecureRandom;
+import javax.crypto.spec.GCMParameterSpec;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -34,9 +36,17 @@ public class AES {
 	public static String encrypt(final String strToEncrypt, final String secret) {
 		try {
 			setKey(secret);
-			Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
-			cipher.init(Cipher.ENCRYPT_MODE, secretKey);
-			return Base64.getEncoder().encodeToString(cipher.doFinal(strToEncrypt.getBytes("UTF-8")));
+			Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+			byte[] iv = new byte[12];
+			SecureRandom secureRandom = new SecureRandom();
+			secureRandom.nextBytes(iv);
+			GCMParameterSpec gcmSpec = new GCMParameterSpec(128, iv);
+			cipher.init(Cipher.ENCRYPT_MODE, secretKey, gcmSpec);
+			byte[] cipherText = cipher.doFinal(strToEncrypt.getBytes("UTF-8"));
+			byte[] encryptedData = new byte[iv.length + cipherText.length];
+			System.arraycopy(iv, 0, encryptedData, 0, iv.length);
+			System.arraycopy(cipherText, 0, encryptedData, iv.length, cipherText.length);
+			return Base64.getEncoder().encodeToString(encryptedData);
 		} catch (Exception e) {
 			System.out.println("Error while encrypting: " + e.toString());
 		}
@@ -46,9 +56,13 @@ public class AES {
 	public static String decrypt(final String strToDecrypt, final String secret) {
 		try {
 			setKey(secret);
-			Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5PADDING");
-			cipher.init(Cipher.DECRYPT_MODE, secretKey);
-			return new String(cipher.doFinal(Base64.getDecoder().decode(strToDecrypt)));
+			Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+			byte[] encryptedData = Base64.getDecoder().decode(strToDecrypt);
+			byte[] iv = Arrays.copyOfRange(encryptedData, 0, 12);
+			byte[] cipherText = Arrays.copyOfRange(encryptedData, 12, encryptedData.length);
+			GCMParameterSpec gcmSpec = new GCMParameterSpec(128, iv);
+			cipher.init(Cipher.DECRYPT_MODE, secretKey, gcmSpec);
+			return new String(cipher.doFinal(cipherText), "UTF-8");
 		} catch (Exception e) {
 			System.out.println("Error while decrypting: " + e.toString());
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/krishnamaddasani/securityProject-app/security/code-scanning/1](https://github.com/krishnamaddasani/securityProject-app/security/code-scanning/1)

To fix the issue, we will replace the use of `AES/ECB/PKCS5Padding` with `AES/GCM/NoPadding`. GCM mode is a secure alternative that provides both encryption and integrity verification. This change requires updating the encryption and decryption methods to use GCM mode, which involves additional steps such as generating a random initialization vector (IV) and handling the GCM authentication tag.

Specifically:
1. Replace `AES/ECB/PKCS5Padding` with `AES/GCM/NoPadding` in both the `encrypt` and `decrypt` methods.
2. Generate a random IV for each encryption operation and prepend it to the ciphertext for use during decryption.
3. Update the decryption method to extract the IV from the ciphertext before initializing the cipher.
4. Use a `GCMParameterSpec` to configure the cipher with the IV and authentication tag length.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
